### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -1,5 +1,6 @@
 name: Test and Release
-
+permissions:
+    contents: read
 # Run this job on all pushes and pull requests
 # as well as tags with a semantic version
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/N-b-dy/ioBroker.oxxify-fan-control/security/code-scanning/3](https://github.com/N-b-dy/ioBroker.oxxify-fan-control/security/code-scanning/3)

To fix this issue, set a `permissions` block at the top/root of your workflow (`.github/workflows/test-and-release.yml`), right after the `name:` and before `on:`. This ensures that by default all jobs (except those that override it, like "deploy") will get the minimal set of permissions. The typical starting point is `contents: read`, which gives the workflow read-only access to repository contents via the GITHUB_TOKEN. The "deploy" job already sets its own permissions (`contents: write`), so nothing more is needed there. No additional imports, methods, or variable definitions are needed for this YAML workflow change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
