### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -2,6 +2,9 @@
 # that is configured in .github/auto-merge.yml
 
 name: Auto-Merge Dependabot PRs
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
     # WARNING: This needs to be run in the PR base, DO NOT build untrusted code in this action


### PR DESCRIPTION
Potential fix for [https://github.com/N-b-dy/ioBroker.oxxify-fan-control/security/code-scanning/1](https://github.com/N-b-dy/ioBroker.oxxify-fan-control/security/code-scanning/1)

To fix the problem, explicitly specify the required permissions using the `permissions` key. The recommendation is to set the minimal set of permissions necessary for the workflow to function. Since the action appears to manipulate pull requests (auto-merging Dependabot PRs), it likely needs `contents: read` (for source code operations) and possibly `pull-requests: write` (in order to perform merges). Add the `permissions` key at the workflow root (top level), just below the `name` field and above `on:`, so it applies to all jobs (and thus to the entire workflow). No changes required in the jobs or steps, just the addition of a `permissions` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
